### PR TITLE
Post service

### DIFF
--- a/backend_services/mediaService/build.gradle
+++ b/backend_services/mediaService/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.3.4'
+    id 'io.spring.dependency-management' version '1.1.6'
+}
+
+group = 'com.example'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(23)
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'io.minio:minio:8.5.2'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+}
+
+bootJar {
+    enabled = true
+}
+
+jar {
+    enabled = false
+}

--- a/backend_services/mediaService/settings.gradle
+++ b/backend_services/mediaService/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'mediaService'

--- a/backend_services/mediaService/src/main/java/onlypans/mediaService/MediaServiceApplication.java
+++ b/backend_services/mediaService/src/main/java/onlypans/mediaService/MediaServiceApplication.java
@@ -1,0 +1,11 @@
+package onlypans.mediaService;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class MediaServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(MediaServiceApplication.class, args);
+    }
+}

--- a/backend_services/mediaService/src/main/java/onlypans/mediaService/controller/MediaController.java
+++ b/backend_services/mediaService/src/main/java/onlypans/mediaService/controller/MediaController.java
@@ -1,0 +1,25 @@
+package onlypans.mediaService.controller;
+
+import onlypans.mediaService.service.MediaService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/media")
+public class MediaController {
+
+    @Autowired
+    private MediaService mediaService;
+
+    @GetMapping("/presigned-url")
+    public ResponseEntity<String> getPresignedUrl(@RequestParam("fileName") String fileName) {
+        try {
+            String url = mediaService.generatePresignedUrl(fileName);
+            return new ResponseEntity<>(url, HttpStatus.OK);
+        } catch (Exception e) {
+            return new ResponseEntity<>("Error: " + e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/backend_services/mediaService/src/main/java/onlypans/mediaService/service/MediaService.java
+++ b/backend_services/mediaService/src/main/java/onlypans/mediaService/service/MediaService.java
@@ -1,0 +1,38 @@
+package onlypans.mediaService.service;
+
+import io.minio.MinioClient;
+import io.minio.errors.*;
+import io.minio.GetPresignedObjectUrlArgs;
+import io.minio.http.Method;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class MediaService {
+
+    private final MinioClient minioClient;
+
+    @Value("${minio.bucket-name}")
+    private String bucketName;
+
+    public MediaService(@Value("${minio.endpoint}") String endpoint,
+                        @Value("${minio.access-key}") String accessKey,
+                        @Value("${minio.secret-key}") String secretKey) {
+        this.minioClient = MinioClient.builder()
+                .endpoint(endpoint)
+                .credentials(accessKey, secretKey)
+                .build();
+    }
+
+    public String generatePresignedUrl(String fileName) throws Exception {
+        return minioClient.getPresignedObjectUrl(
+                GetPresignedObjectUrlArgs.builder()
+                        .bucket(bucketName)
+                        .object(fileName)
+                        .method(Method.PUT)
+                        .expiry(15, TimeUnit.MINUTES)
+                        .build()
+        );
+    }
+}

--- a/backend_services/mediaService/src/main/resources/application.properties
+++ b/backend_services/mediaService/src/main/resources/application.properties
@@ -1,0 +1,8 @@
+# Server configuration
+server.port=8085
+
+# MinIO configuration
+minio.endpoint=https://cdn-api.kobos.io/
+minio.access-key=######
+minio.secret-key=######
+minio.bucket-name=onlypans-content

--- a/backend_services/postService/build.gradle
+++ b/backend_services/postService/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'mysql:mysql-connector-java:8.0.32'
+    runtimeOnly 'org.postgresql:postgresql:42.5.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 

--- a/backend_services/postService/src/main/java/onlypans/postService/config/CorsConfig.java
+++ b/backend_services/postService/src/main/java/onlypans/postService/config/CorsConfig.java
@@ -1,0 +1,23 @@
+package onlypans.postService.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig {
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}

--- a/backend_services/postService/src/main/java/onlypans/postService/controller/PostController.java
+++ b/backend_services/postService/src/main/java/onlypans/postService/controller/PostController.java
@@ -40,4 +40,10 @@ public class PostController {
         String presignedUrl = postService.getPresignedUrl(fileName);
         return new ResponseEntity<>(presignedUrl, HttpStatus.OK);
     }
+
+    @GetMapping
+    public ResponseEntity<List<Post>> getAllPosts() {
+        List<Post> posts = postService.getAllPosts();
+        return new ResponseEntity<>(posts, HttpStatus.OK);
+    }
 }

--- a/backend_services/postService/src/main/java/onlypans/postService/controller/PostController.java
+++ b/backend_services/postService/src/main/java/onlypans/postService/controller/PostController.java
@@ -13,23 +13,31 @@ import java.util.List;
 @RequestMapping("/posts")
 public class PostController {
     // api endpoints for post application
-    @Autowired
-    private PostService postService;
+    private final PostService postService;
 
-    @PostMapping
-    public ResponseEntity<Post> createPost(@RequestBody Post post) {
-        return new ResponseEntity<>(postService.createPost(post), HttpStatus.CREATED);
+    @Autowired
+    public PostController(PostService postService) {
+        this.postService = postService;
     }
 
-    @GetMapping("/{id}")
+    @PostMapping
+    public ResponseEntity<Post> createPost(@RequestBody Post post, @RequestParam String fileName) {
+        if (post == null || fileName == null || fileName.isEmpty()) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+        return new ResponseEntity<>(postService.createPost(post, fileName), HttpStatus.CREATED);
+    }
+
+    @GetMapping("/{id:\\d+}")
     public ResponseEntity<Post> getPostById(@PathVariable Long id) {
         return postService.getPostById(id)
                 .map(post -> new ResponseEntity<>(post, HttpStatus.OK))
                 .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
     }
 
-    @GetMapping
-    public List<Post> getAllPosts() {
-        return postService.getAllPosts();
+    @GetMapping("/media_url")
+    public ResponseEntity<String> getPresignedUrl(@RequestParam String fileName) {
+        String presignedUrl = postService.getPresignedUrl(fileName);
+        return new ResponseEntity<>(presignedUrl, HttpStatus.OK);
     }
 }

--- a/backend_services/postService/src/main/java/onlypans/postService/entity/Post.java
+++ b/backend_services/postService/src/main/java/onlypans/postService/entity/Post.java
@@ -1,9 +1,9 @@
 package onlypans.postService.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Entity
 public class Post {
@@ -11,10 +11,39 @@ public class Post {
 @Id
 @GeneratedValue(strategy = GenerationType.IDENTITY)
 private Long id;
+private String contentDescription;
+private String authorName;
+private String mediaUrl;
+private LocalDateTime timestamp;
+
+
+    @PrePersist
+    public void prePersist() {
+        if (this.timestamp == null) {
+            this.timestamp = LocalDateTime.now();
+        }
+    }
 
 
     // Getters and setters
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
+
+    public String getContentDescription() { return contentDescription; }
+    public void setContentDescription(String contentDescription) { this.contentDescription = contentDescription; }
+
+    public String getAuthorName() { return authorName; }
+    public void setAuthorName(String authorName) { this.authorName = authorName; }
+
+    public String getMediaUrl() { return mediaUrl; }
+    public void setMediaUrl(String mediaUrl) { this.mediaUrl = mediaUrl; }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(LocalDateTime timestamp) {
+        this.timestamp = timestamp;
+    }
 
 }

--- a/backend_services/postService/src/main/java/onlypans/postService/service/PostService.java
+++ b/backend_services/postService/src/main/java/onlypans/postService/service/PostService.java
@@ -4,6 +4,9 @@ import onlypans.postService.entity.Post;
 import onlypans.postService.repository.PostRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.beans.factory.annotation.Value;
+
 
 import java.util.List;
 import java.util.Optional;
@@ -14,7 +17,15 @@ public class PostService {
     @Autowired
     private PostRepository postRepository;
 
-    public Post createPost(Post post) {
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    @Value("${media.service.url}")
+    private String mediaServiceUrl;
+
+
+    public Post createPost(Post post, String fileName) {
+        String presignedUrl = restTemplate.getForObject(mediaServiceUrl + "/presigned-url?fileName=" + fileName, String.class);
+        post.setMediaUrl(presignedUrl);
         return postRepository.save(post);
     }
 
@@ -26,9 +37,11 @@ public class PostService {
         return postRepository.findAll();
     }
 
-
-
     public void deletePost(Long id) {
         postRepository.deleteById(id);
+    }
+
+    public String getPresignedUrl(String fileName) {
+        return restTemplate.getForObject(mediaServiceUrl + "/presigned-url?fileName=" + fileName, String.class);
     }
 }

--- a/backend_services/postService/src/main/resources/application.properties
+++ b/backend_services/postService/src/main/resources/application.properties
@@ -2,14 +2,21 @@
 server.port=8082
 
 # Database configuration
-spring.datasource.url=jdbc:mysql://localhost:(port local db is on)/(db name)
-spring.datasource.username= db username
-spring.datasource.password= db pass
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+#spring.datasource.url=jdbc:mysql://localhost:(port local db is on)/(db name)
+#spring.datasource.username= db username
+#spring.datasource.password= db pass
+#spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 # this driver is needed to translate java database api calls to sql queries that the db can understand
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/postgres
+spring.datasource.username=postgres
+spring.datasource.password=dsfs23sdf636!23sada13
+spring.datasource.driver-class-name=org.postgresql.Driver
+media.service.url=http://localhost:8085/media
 
 
 # JPA configuration
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+#spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect

--- a/frontend/onlypans-frontend/package-lock.json
+++ b/frontend/onlypans-frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.7.7",
+        "date-fns": "^4.1.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
@@ -7752,6 +7753,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/frontend/onlypans-frontend/package-lock.json
+++ b/frontend/onlypans-frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.7.7",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-scripts": "5.0.1",
@@ -6211,6 +6212,31 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.7.tgz",
+      "integrity": "sha512-S4kL7XrjgBmvdGut0sN3yJxqYzrDOnivkBiN0OFs6hLiUam3UPvswUo0kqGyhqUZGEOytHyumEdXsAkgCOUf3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -16275,6 +16301,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/frontend/onlypans-frontend/package.json
+++ b/frontend/onlypans-frontend/package.json
@@ -10,6 +10,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.7.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",

--- a/frontend/onlypans-frontend/package.json
+++ b/frontend/onlypans-frontend/package.json
@@ -11,6 +11,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.7.7",
+    "date-fns": "^4.1.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",

--- a/frontend/onlypans-frontend/src/App.js
+++ b/frontend/onlypans-frontend/src/App.js
@@ -1,11 +1,13 @@
 import './App.css';
 import ResponsiveAppBar from "./components/appbar";
-import PostCard from "./components/post";
 import CreatePost from "./components/createpost";
-import { useState } from 'react';
+import PostCard from "./components/post";
+import { useState, useEffect } from 'react';
+import axios from 'axios';
 
 function App() {
     const [showCreatePost, setShowCreatePost] = useState(false);
+    const [posts, setPosts] = useState([]);
 
     const handleToggleCreatePost = () => {
         setShowCreatePost((prev) => !prev);
@@ -13,22 +15,33 @@ function App() {
 
     const handlePostCreate = (newPost) => {
         alert("Post created successfully!");
-        console.log("New post created:", newPost);
+        setPosts((prevPosts) => [newPost, ...prevPosts]);
     };
+
+
+
+    // We are returning all posts for the minute, we will need to consider subscriptions, etc.
+    useEffect(() => {
+        const fetchPosts = async () => {
+            try {
+                const response = await axios.get('http://localhost:8082/posts');
+                setPosts(response.data);
+            } catch (error) {
+                console.error('Error fetching posts:', error);
+            }
+        };
+        fetchPosts();
+    }, []);
 
     return (
         <div>
             <ResponsiveAppBar onToggleCreatePost={handleToggleCreatePost} />
-
             <CreatePost open={showCreatePost} onClose={handleToggleCreatePost} onPostCreate={handlePostCreate} />
 
             <div style={styles.scrollableContainer}>
-                <PostCard />
-                <PostCard />
-                <PostCard />
-                <PostCard />
-                <PostCard />
-                <PostCard />
+                {posts.map((post) => (
+                    <PostCard key={post.id} post={post} />
+                ))}
             </div>
         </div>
     );

--- a/frontend/onlypans-frontend/src/App.js
+++ b/frontend/onlypans-frontend/src/App.js
@@ -1,22 +1,37 @@
 import './App.css';
 import ResponsiveAppBar from "./components/appbar";
 import PostCard from "./components/post";
+import CreatePost from "./components/createpost";
+import { useState } from 'react';
 
 function App() {
-  return (
-      <div>
-          <ResponsiveAppBar/>
+    const [showCreatePost, setShowCreatePost] = useState(false);
 
-          <div style={styles.scrollableContainer}>
-              <PostCard/>
-              <PostCard/>
-              <PostCard/>
-              <PostCard/>
-              <PostCard/>
-              <PostCard/>
-          </div>
-      </div>
-  );
+    const handleToggleCreatePost = () => {
+        setShowCreatePost((prev) => !prev);
+    };
+
+    const handlePostCreate = (newPost) => {
+        alert("Post created successfully!");
+        console.log("New post created:", newPost);
+    };
+
+    return (
+        <div>
+            <ResponsiveAppBar onToggleCreatePost={handleToggleCreatePost} />
+
+            <CreatePost open={showCreatePost} onClose={handleToggleCreatePost} onPostCreate={handlePostCreate} />
+
+            <div style={styles.scrollableContainer}>
+                <PostCard />
+                <PostCard />
+                <PostCard />
+                <PostCard />
+                <PostCard />
+                <PostCard />
+            </div>
+        </div>
+    );
 }
 
 const styles = {

--- a/frontend/onlypans-frontend/src/components/appbar.js
+++ b/frontend/onlypans-frontend/src/components/appbar.js
@@ -12,18 +12,12 @@ import Button from '@mui/material/Button';
 import Tooltip from '@mui/material/Tooltip';
 import MenuItem from '@mui/material/MenuItem';
 import logo from '../assets/textOnly.png';
-import user from '../assets/user.png'
-
-
-/*
-*  Source: https://mui.com/material-ui/react-app-bar/#app-bar-with-responsive-menu
-* */
-
+import user from '../assets/user.png';
 
 const pages = ['']; // Placeholder
 const settings = ['Profile', 'Logout'];
 
-function ResponsiveAppBar() {
+function ResponsiveAppBar({ onToggleCreatePost }) {
     const [anchorElNav, setAnchorElNav] = React.useState(null);
     const [anchorElUser, setAnchorElUser] = React.useState(null);
 
@@ -43,7 +37,7 @@ function ResponsiveAppBar() {
     };
 
     return (
-        <AppBar position="static" sx={{ backgroundColor: '#fff'}}>
+        <AppBar position="static" sx={{ backgroundColor: '#fff' }}>
             <Container maxWidth="xl">
                 <Toolbar disableGutters>
                     <Typography
@@ -98,41 +92,27 @@ function ResponsiveAppBar() {
                             ))}
                         </Menu>
                     </Box>
-                    <Typography
-                        variant="h5"
-                        noWrap
-                        component="a"
-                        href="#app-bar-with-responsive-menu"
-                        sx={{
-                            mr: 2,
-                            display: { xs: 'flex', md: 'none' },
-                            flexGrow: 1,
-                            fontFamily: 'monospace',
-                            fontWeight: 700,
-                            letterSpacing: '.3rem',
-                            color: 'inherit',
-                            textDecoration: 'none',
-                        }}
-                    >
-                        LOGO
-                    </Typography>
+
                     <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
                         {pages.map((page) => (
                             <Button
                                 key={page}
                                 onClick={handleCloseNavMenu}
-                                sx={{ my: 2, color: 'white', display: 'block' }}
+                                sx={{ my: 2, color: 'black', display: 'block' }}
                             >
                                 {page}
                             </Button>
                         ))}
                     </Box>
+
+                    <Button variant="contained" color="primary" onClick={onToggleCreatePost} sx={{ mr: 2 }}>
+                        Create Post
+                    </Button>
+
                     <Box sx={{ flexGrow: 0 }}>
                         <Tooltip title="Open settings">
-
                             <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
                                 <Avatar alt="User Profile Picture" src={user} />
-
                             </IconButton>
                         </Tooltip>
                         <Menu

--- a/frontend/onlypans-frontend/src/components/createpost.js
+++ b/frontend/onlypans-frontend/src/components/createpost.js
@@ -1,0 +1,161 @@
+import axios from 'axios';
+import * as React from 'react';
+import { useState } from 'react';
+import { Card, CardContent, CardMedia, Typography, Avatar, Box, TextField, Button, Modal, Backdrop, Snackbar, Alert } from '@mui/material';
+import placeholder from '../assets/placeholder.jpg';
+import user from '../assets/user.png';
+
+function CreatePost({ open, onClose }) {
+    const [content, setContent] = useState('');
+    const [image, setImage] = useState(null);
+    const [preview, setPreview] = useState(placeholder);
+    const [successOpen, setSuccessOpen] = useState(false);
+
+    const handleImageChange = (e) => {
+        const file = e.target.files[0];
+        if (file) {
+            setImage(file);
+            setPreview(URL.createObjectURL(file));
+        }
+    };
+
+    const handleSubmit = async (e) => {
+        e.preventDefault();
+
+        if (!image) {
+            alert('Please upload an image!');
+            return;
+        }
+
+        try {
+            // Requesting the presigned URL from postService
+            const fileName = image.name;
+            console.log(`Requesting presigned URL for: ${fileName}`);
+            const { data: postResponse } = await axios.post('http://localhost:8082/posts', {
+                contentDescription: content,
+                authorName: 'someone' // we will set this dynamically once we have user/creator service ready
+            }, {
+                params: { fileName }
+            });
+
+            // Extracting the presigned URL for upload
+            const presignedUrl = postResponse.mediaUrl;
+
+            // Uploading the image using the presigned URL
+            await axios.put(presignedUrl, image, {
+                headers: {
+                    'Content-Type': image.type
+                }
+            });
+
+            setContent('');
+            setImage(null);
+            setPreview(placeholder);
+            setSuccessOpen(true);
+            onClose();
+
+        } catch (error) {
+            console.error('Error creating post:', error);
+            alert('There was an error creating the post.');
+        }
+    };
+
+    const handleCloseSuccess = () => {
+        setSuccessOpen(false);
+    };
+
+    return (
+        <>
+            <Modal
+                open={open}
+                onClose={onClose}
+                closeAfterTransition
+                BackdropComponent={Backdrop}
+                BackdropProps={{
+                    timeout: 500,
+                    style: { backgroundColor: 'rgba(0, 0, 0, 0.5)' },
+                }}
+            >
+                <Box
+                    sx={{
+                        position: 'absolute',
+                        top: '50%',
+                        left: '50%',
+                        transform: 'translate(-50%, -50%)',
+                        width: 750,
+                        bgcolor: 'background.paper',
+                        boxShadow: 24,
+                        borderRadius: 4,
+                        p: 4,
+                    }}
+                >
+                    <Card>
+                        <CardContent>
+                            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                                <Avatar alt="OnlyPans User" src={user} />
+                                <Typography variant="body2" color="text.primary" sx={{ ml: 2 }}>
+                                    Create a new post
+                                </Typography>
+                            </Box>
+
+                            <CardMedia
+                                component="img"
+                                height="400"
+                                image={preview}
+                                alt="preview"
+                                sx={{ mb: 2 }}
+                            />
+
+                            <Button
+                                variant="contained"
+                                component="label"
+                                sx={{ mb: 2 }}
+                            >
+                                Upload Image
+                                <input
+                                    type="file"
+                                    accept="image/*"
+                                    onChange={handleImageChange}
+                                    hidden
+                                />
+                            </Button>
+
+                            <Box component="form" onSubmit={handleSubmit}>
+                                <TextField
+                                    label="Description"
+                                    variant="outlined"
+                                    fullWidth
+                                    multiline
+                                    rows={4}
+                                    value={content}
+                                    onChange={(e) => setContent(e.target.value)}
+                                    sx={{ mb: 2 }}
+                                />
+
+                                <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                                    <Button type="submit" variant="contained" color="primary">
+                                        Post
+                                    </Button>
+                                </Box>
+                            </Box>
+                        </CardContent>
+                    </Card>
+                </Box>
+            </Modal>
+
+
+            <Snackbar
+                open={successOpen}
+                autoHideDuration={3000}
+                onClose={handleCloseSuccess}
+                anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+            >
+                <Alert onClose={handleCloseSuccess} severity="success" sx={{ width: '100%' }}>
+                    Post created successfully!
+                </Alert>
+            </Snackbar>
+        </>
+    );
+}
+
+export default CreatePost;

--- a/frontend/onlypans-frontend/src/components/post.js
+++ b/frontend/onlypans-frontend/src/components/post.js
@@ -1,44 +1,57 @@
 import * as React from 'react';
 import { Card, CardContent, CardMedia, Typography, Avatar, Box, IconButton } from '@mui/material';
-import user from '../assets/user.png'
-import like from '../assets/icons/like.png'
-import comment from '../assets/icons/speech-bubble.png'
-import placeholder from '../assets/placeholder.jpg'
+import user from '../assets/user.png';
+import like from '../assets/icons/like.png';
+import comment from '../assets/icons/speech-bubble.png';
+import placeholder from '../assets/placeholder.jpg';
+import { formatDistanceToNow } from 'date-fns';
 
-function PostCard() {
+function PostCard({ post }) {
+
+
+    const cleanMediaUrl = post.mediaUrl ? post.mediaUrl.split('?')[0] : placeholder;
+
+    const formattedTimestamp = post.timestamp
+        ? formatDistanceToNow(new Date(post.timestamp), { addSuffix: true })
+        : '';
+
+    console.log(cleanMediaUrl);
+
     return (
-        <Card sx={{ maxWidth: 750, borderRadius: 4, boxShadow: 3 }}>
+        <Card sx={{
+            width: 600,
+            height: 800,
+            borderRadius: 4,
+            boxShadow: 3,
+            display: 'flex',
+            flexDirection: 'column',
+        }}>
             <CardMedia
                 component="img"
-                height="400"
-                image={placeholder}
-                alt="food picture"
+                image={cleanMediaUrl}
+                alt="post image"
+                sx={{
+                    width: '100%',
+                    height: 600,
+                    objectFit: 'cover',
+                }}
             />
 
-            <CardContent>
-                {/* Page button placeholders */}
-                <Box sx={{ display: 'flex', justifyContent: 'center', mt: 2 }}>
-                    <Box sx={{ width: 10, height: 10, bgcolor: 'black', borderRadius: '50%', mx: 0.5 }} />
-                    <Box sx={{ width: 10, height: 10, bgcolor: 'gray', borderRadius: '50%', mx: 0.5 }} />
-                    <Box sx={{ width: 10, height: 10, bgcolor: 'gray', borderRadius: '50%', mx: 0.5 }} />
-                </Box>
-
+            <CardContent sx={{ flex: 1, display: 'flex', flexDirection: 'column', justifyContent: 'space-between' }}>
                 <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-                    <Avatar alt="John Doe" src={user} />
+                    <Avatar alt={post.authorName || "User"} src={user} />
                     <Box sx={{ ml: 2 }}>
                         <Typography variant="body2" color="text.primary">
-                            OnlyPans User
+                            {post.authorName || "OnlyPans User"} {formattedTimestamp && `- ${formattedTimestamp}`}
                         </Typography>
                     </Box>
                 </Box>
 
-
-                {/* post content */}
-                <Typography variant="body2" color="text.secondary">
-                    pay for my OnlyPans and see more! 🤤
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+                    {post.contentDescription || "Check out this recipe!"}
                 </Typography>
 
-                <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
                     <IconButton aria-label="like">
                         <img src={like} alt="like" style={{ height: '24px', width: '24px' }} />
                     </IconButton>

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,5 +5,6 @@ include 'backend_services:userService'
 include 'backend_services:postService'
 include 'backend_services:creatorService'
 include 'backend_services:subscriptionService'
+include 'backend_services:mediaService'
 findProject(':backend_services:subscriptionService')?.name = 'subscriptionService'
 


### PR DESCRIPTION
This pull request contains the initial implementation of two services
**postService**, **mediaService**

- mediaService is responsible for creating presigned URLs from our CDN (MinIO)
- When a user creates a post it will first request a presigned URL from the mediaService for the filename
- We then make a PUT request to this URL, directly uploading the file as a binary format straight to the MinIO server.

- On the frontend, there is now a 'create post' button. For now, it's always displayed. But it should have a check to see whether a user is a creator or standard user. 
- Posts dynamically populate the react frontend, although there is no way to distinguish subscription tiers for the time being. I will need the user service and subscription service before I can make any more changes in regards to this. It is displayed currently by a simple call to retrieve all posts from the post service.
 