### PR TITLE
Add CI/CD + Deploy To Web

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Copy Environment Files
         run: |
           mkdir -p ./configs
-          cp /home/github-runner/envs/* ./configs/
+          cp -r /home/github-runner/envs/* ./configs/
 
       - name: Set Up Java
         uses: actions/setup-java@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           mkdir -p ./configs
           cp -r /home/github-runner/envs/* ./configs/
-          cp ./configs/docker-compose-static.yml ./docker-compose.yml
+          cp ./configs/docker-compose.yml ./
 
       # Set Up Java
       - name: Set Up Java

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,4 +62,4 @@ jobs:
       - name: Deploy with Docker Compose
         run: |
           docker compose -p onlypans down
-          docker compose -p onlypans up -d
+          docker compose -p onlypans up --build -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,22 +38,18 @@ jobs:
       # Ensure gradlew is executable
       - name: Ensure gradlew is Executable
         run: |
-          chmod +x backend_services/subscriptionService/gradlew
-          chmod +x backend_services/userService/gradlew
-          chmod +x backend_services/postService/gradlew
-          chmod +x backend_services/mediaService/gradlew
-          chmod +x backend_services/creatorService/gradlew
-          chmod +x api_gateway/gradlew
+          chmod +x gradlew
+          find . -name "gradlew" -exec chmod +x {} \;
 
       # Build Backend JARs
       - name: Build JARs
         run: |
-          cd backend_services/subscriptionService && ./gradlew clean build -x test && cd -
-          cd backend_services/userService && ./gradlew clean build -x test && cd -
-          cd backend_services/postService && ./gradlew clean build -x test && cd -
-          cd backend_services/mediaService && ./gradlew clean build -x test && cd -
-          cd backend_services/creatorService && ./gradlew clean build -x test && cd -
-          cd api_gateway && ./gradlew clean build -x test && cd -
+          ./gradlew -p backend_services/subscriptionService clean build -x test || echo "No gradlew in subscriptionService"
+          ./gradlew -p backend_services/userService clean build -x test || echo "No gradlew in userService"
+          ./gradlew -p backend_services/postService clean build -x test || echo "No gradlew in postService"
+          ./gradlew -p backend_services/mediaService clean build -x test || echo "No gradlew in mediaService"
+          ./gradlew -p backend_services/creatorService clean build -x test || echo "No gradlew in creatorService"
+          ./gradlew -p api_gateway clean build -x test || echo "No gradlew in api_gateway"
 
       # Debug Built Files
       - name: Debug Built JARs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,4 +63,3 @@ jobs:
         run: |
           docker compose -p onlypans down
           docker compose -p onlypans up -d
-          docker restart $(docker ps --filter "name=uni-onlypans-frontend" --format "{{.ID}}" | head -n 1) 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Copy Environment Files
         run: |
           mkdir -p ./configs
-          cp /home/github-actions/envs/* ./configs/
+          cp /home/github-runner/envs/* ./configs/
 
       - name: Set Up Java
         uses: actions/setup-java@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           mkdir -p ./configs
           cp -r /home/github-runner/envs/* ./configs/
-          cp ./configs/docker-compose.yml ./
+          cp ./configs/docker-compose-static.yml ./docker-compose.yml
 
       # Set Up Java
       - name: Set Up Java

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           mkdir -p ./configs
           cp -r /home/github-runner/envs/* ./configs/
-          cp ./configs/docker-compose.yml ./
+          mv ./live-docker-compose.yml ./docker-compose.yml
 
       # Set Up Java
       - name: Set Up Java

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           mkdir -p ./configs
           cp -r /home/github-runner/envs/* ./configs/
+          cp ./configs/docker-compose.yml ./
 
       # Set Up Java
       - name: Set Up Java
@@ -60,5 +61,5 @@ jobs:
       # Deploy with Docker Compose
       - name: Deploy with Docker Compose
         run: |
-          docker compose -p onlypans down
-          docker compose -p onlypans up -d
+          sudo docker compose -p onlypans down
+          sudo docker compose -p onlypans up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,41 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+      - livemode
+
+jobs:
+  build-and-deploy:
+    runs-on: self-hosted
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Copy Environment Files
+        run: |
+          mkdir -p ./configs
+          cp /home/github-actions/envs/* ./configs/
+
+      - name: Set Up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Build JARs
+        run: |
+          cd backend_services/subscriptionService && ./gradlew clean build -x test && cd -
+          cd backend_services/userService && ./gradlew clean build -x test && cd -
+          cd backend_services/postService && ./gradlew clean build -x test && cd -
+          cd backend_services/mediaService && ./gradlew clean build -x test && cd -
+          cd backend_services/creatorService && ./gradlew clean build -x test && cd -
+          cd api_gateway && ./gradlew clean build -x test && cd -
+
+      # Deploy with Docker Compose
+      - name: Deploy with Docker Compose
+        run: |
+          docker compose -p onlypans down
+          docker compose -p onlypans up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,5 +61,5 @@ jobs:
       # Deploy with Docker Compose
       - name: Deploy with Docker Compose
         run: |
-          sudo docker compose -p onlypans down
-          sudo docker compose -p onlypans up -d
+          docker compose -p onlypans down
+          docker compose -p onlypans up -d

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -58,8 +58,9 @@ jobs:
           echo "Built JARs:"
           find . -name "*.jar" -print
 
-      # Deploy with Docker Compose
+      # Deploy with Docker Compose + restart our reverse proxy
       - name: Deploy with Docker Compose
         run: |
           docker compose -p onlypans down
           docker compose -p onlypans up -d
+          docker restart $(docker ps --filter "name=uni-onlypans-frontend" --format "{{.ID}}" | head -n 1) 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,20 +11,41 @@ jobs:
     runs-on: self-hosted
 
     steps:
+      # Checkout the repository
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      # Debug Directory Structure
+      - name: Debug Directory Structure
+        run: |
+          echo "Current Directory: $(pwd)"
+          echo "Repository Contents:"
+          ls -R
+
+      # Copy Environment Files
       - name: Copy Environment Files
         run: |
           mkdir -p ./configs
           cp -r /home/github-runner/envs/* ./configs/
 
+      # Set Up Java
       - name: Set Up Java
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '21'
 
+      # Ensure gradlew is executable
+      - name: Ensure gradlew is Executable
+        run: |
+          chmod +x backend_services/subscriptionService/gradlew
+          chmod +x backend_services/userService/gradlew
+          chmod +x backend_services/postService/gradlew
+          chmod +x backend_services/mediaService/gradlew
+          chmod +x backend_services/creatorService/gradlew
+          chmod +x api_gateway/gradlew
+
+      # Build Backend JARs
       - name: Build JARs
         run: |
           cd backend_services/subscriptionService && ./gradlew clean build -x test && cd -
@@ -33,6 +54,12 @@ jobs:
           cd backend_services/mediaService && ./gradlew clean build -x test && cd -
           cd backend_services/creatorService && ./gradlew clean build -x test && cd -
           cd api_gateway && ./gradlew clean build -x test && cd -
+
+      # Debug Built Files
+      - name: Debug Built JARs
+        run: |
+          echo "Built JARs:"
+          find . -name "*.jar" -print
 
       # Deploy with Docker Compose
       - name: Deploy with Docker Compose

--- a/api_gateway/src/main/java/onlypans/api_gateway/security/SecurityConfig.java
+++ b/api_gateway/src/main/java/onlypans/api_gateway/security/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration corsConfig = new CorsConfiguration();
         corsConfig.addAllowedOrigin("http://localhost:3000");
+        corsConfig.addAllowedOrigin("https://uni-onlypans-frontend.kobos.studio");
         corsConfig.addAllowedMethod("*");
         corsConfig.addAllowedHeader("*");
         corsConfig.setAllowCredentials(true);

--- a/api_gateway/src/main/resources/application.properties
+++ b/api_gateway/src/main/resources/application.properties
@@ -6,7 +6,7 @@ spring.main.allow-bean-definition-overriding=true
 logging.level.org.springframework.security=DEBUG
 logging.level.org.springframework.boot.autoconfigure.security=DEBUG
 
-spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8081/realms/onlypans
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_LIVE_URL:http://localhost:8081/realms/onlypans}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://keycloak:8081/realms/onlypans/protocol/openid-connect/certs
 
 # Consul Configuration
@@ -26,30 +26,35 @@ spring.cloud.gateway.routes[0].id=${USER_SERVICE_ROUTE_ID:userService}
 spring.cloud.gateway.routes[0].uri=${USER_SERVICE_ROUTE_URI:lb://user-service}
 spring.cloud.gateway.routes[0].predicates[0]=Path=${USER_SERVICE_PATH:/users/**}
 spring.cloud.gateway.routes[0].filters[0]=PreserveHostHeader
+spring.cloud.gateway.routes[0].filters[1]=StripPrefix=${STRIP_PREF:0}
 
 # Creator Service Route
 spring.cloud.gateway.routes[1].id=${CREATOR_SERVICE_ROUTE_ID:creatorService}
 spring.cloud.gateway.routes[1].uri=${CREATOR_SERVICE_ROUTE_URI:lb://creator-service}
 spring.cloud.gateway.routes[1].predicates[0]=Path=${CREATOR_SERVICE_PATH:/creator-profiles/**}
 spring.cloud.gateway.routes[1].filters[0]=PreserveHostHeader
+spring.cloud.gateway.routes[1].filters[1]=StripPrefix=${STRIP_PREF:0}
 
 # Subscription Service Route
 spring.cloud.gateway.routes[2].id=${SUBSCRIPTION_SERVICE_ROUTE_ID:subscriptionService}
 spring.cloud.gateway.routes[2].uri=${SUBSCRIPTION_SERVICE_ROUTE_URI:lb://subscription-service}
 spring.cloud.gateway.routes[2].predicates[0]=Path=${SUBSCRIPTION_SERVICE_PATH:/subscriptions/**}
 spring.cloud.gateway.routes[2].filters[0]=PreserveHostHeader
+spring.cloud.gateway.routes[2].filters[1]=StripPrefix=${STRIP_PREF:0}
 
 # Post Service Route
 spring.cloud.gateway.routes[3].id=${POST_SERVICE_ROUTE_ID:postService}
 spring.cloud.gateway.routes[3].uri=${POST_SERVICE_ROUTE_URI:lb://post-service}
 spring.cloud.gateway.routes[3].predicates[0]=Path=${POST_SERVICE_PATH:/posts/**}
 spring.cloud.gateway.routes[3].filters[0]=PreserveHostHeader
+spring.cloud.gateway.routes[3].filters[1]=StripPrefix=${STRIP_PREF:0}
 
 # Media Service Route
 spring.cloud.gateway.routes[4].id=${MEDIA_SERVICE_ROUTE_ID:mediaService}
 spring.cloud.gateway.routes[4].uri=${MEDIA_SERVICE_ROUTE_URI:lb://media-service}
 spring.cloud.gateway.routes[4].predicates[0]=Path=${MEDIA_SERVICE_PATH:/media/**}
 spring.cloud.gateway.routes[4].filters[0]=PreserveHostHeader
+spring.cloud.gateway.routes[4].filters[1]=StripPrefix=${STRIP_PREF:0}
 
 # CORS Debug and Prevention of header stripping of responses
 logging.level.org.springframework.web=DEBUG

--- a/backend_services/creatorService/src/main/resources/application.properties
+++ b/backend_services/creatorService/src/main/resources/application.properties
@@ -37,5 +37,5 @@ spring.cloud.consul.discovery.health-check-interval=30s
 spring.cloud.consul.discovery.prefer-ip-address=true
 
 # Security
-spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8081/realms/onlypans
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_LIVE_URL:http://localhost:8081/realms/onlypans}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://keycloak:8081/realms/onlypans/protocol/openid-connect/certs

--- a/backend_services/mediaService/build.gradle
+++ b/backend_services/mediaService/build.gradle
@@ -25,6 +25,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-consul-discovery'
     implementation 'org.springframework.cloud:spring-cloud-starter-consul-config'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
 }
 dependencyManagement {
     imports {

--- a/backend_services/mediaService/src/main/java/onlypans/mediaService/security/SecurityConfig.java
+++ b/backend_services/mediaService/src/main/java/onlypans/mediaService/security/SecurityConfig.java
@@ -1,0 +1,22 @@
+package onlypans.mediaService.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/actuator/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt());
+
+        return http.build();
+    }
+}

--- a/backend_services/mediaService/src/main/resources/application.properties
+++ b/backend_services/mediaService/src/main/resources/application.properties
@@ -26,3 +26,7 @@ spring.cloud.consul.config.failFast=false
 
 # setting service to be discoverable using IP address
 spring.cloud.consul.discovery.prefer-ip-address=true
+
+# Security
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_LIVE_URL:http://localhost:8081/realms/onlypans}
+spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://keycloak:8081/realms/onlypans/protocol/openid-connect/certs

--- a/backend_services/postService/src/main/resources/application.properties
+++ b/backend_services/postService/src/main/resources/application.properties
@@ -37,5 +37,5 @@ spring.cloud.consul.discovery.health-check-interval=${SPRING_CLOUD_CONSUL_HEALTH
 spring.cloud.consul.discovery.prefer-ip-address=true
 
 # Security
-spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8081/realms/onlypans
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_LIVE_URL:http://localhost:8081/realms/onlypans}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://keycloak:8081/realms/onlypans/protocol/openid-connect/certs

--- a/backend_services/subscriptionService/src/main/resources/application.properties
+++ b/backend_services/subscriptionService/src/main/resources/application.properties
@@ -36,7 +36,7 @@ stripe.sk=${STRIPE_SK}
 stripe.whsec=${STRIPE_WHSEC}
 
 # Security
-spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8081/realms/onlypans
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_LIVE_URL:http://localhost:8081/realms/onlypans}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://keycloak:8081/realms/onlypans/protocol/openid-connect/certs
 logging.level.feign=DEBUG
 logging.level.onlypans.subscriptionService.clients.UserServiceClient=DEBUG

--- a/backend_services/userService/src/main/resources/application.properties
+++ b/backend_services/userService/src/main/resources/application.properties
@@ -33,5 +33,5 @@ spring.cloud.consul.discovery.health-check-interval=30s
 spring.cloud.consul.discovery.prefer-ip-address=true
 
 # Security
-spring.security.oauth2.resourceserver.jwt.issuer-uri=http://localhost:8081/realms/onlypans
+spring.security.oauth2.resourceserver.jwt.issuer-uri=${KEYCLOAK_LIVE_URL:http://localhost:8081/realms/onlypans}
 spring.security.oauth2.resourceserver.jwt.jwk-set-uri=http://keycloak:8081/realms/onlypans/protocol/openid-connect/certs

--- a/frontend/onlypans-frontend/src/api/PostServiceApi.js
+++ b/frontend/onlypans-frontend/src/api/PostServiceApi.js
@@ -1,9 +1,12 @@
 import axios from 'axios';
 
-export const getPresignedUrl = async (fileName) => {
+export const getPresignedUrl = async (fileName, token) => {
     try {
         const { data } = await axios.get(`${process.env.REACT_APP_API_GATEWAY_URL}/media/presigned-url`, {
             params: { fileName },
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
         });
         return data;
     } catch (error) {
@@ -11,7 +14,6 @@ export const getPresignedUrl = async (fileName) => {
         throw error;
     }
 };
-
 
 export const uploadFile = async (presignedUrl, file) => {
     try {
@@ -24,17 +26,19 @@ export const uploadFile = async (presignedUrl, file) => {
     }
 };
 
-
-export const createPost = async (postContent) => {
+export const createPost = async (postContent, token) => {
     try {
-        const { data } = await axios.post(`${process.env.REACT_APP_API_GATEWAY_URL}/posts`, postContent);
+        const { data } = await axios.post(`${process.env.REACT_APP_API_GATEWAY_URL}/posts`, postContent, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
         return data;
     } catch (error) {
         console.error('Error creating post:', error);
         throw error;
     }
 };
-
 
 export const fetchPosts = async (token) => {
     try {

--- a/frontend/onlypans-frontend/src/api/PostServiceApi.js
+++ b/frontend/onlypans-frontend/src/api/PostServiceApi.js
@@ -1,18 +1,51 @@
-import axios from "axios";
+import axios from 'axios';
+
+export const getPresignedUrl = async (fileName) => {
+    try {
+        const { data } = await axios.get(`${process.env.REACT_APP_MEDIA_SERVICE_URL}/media/presigned-url`, {
+            params: { fileName },
+        });
+        return data;
+    } catch (error) {
+        console.error('Error fetching presigned URL:', error);
+        throw error;
+    }
+};
+
+
+export const uploadFile = async (presignedUrl, file) => {
+    try {
+        await axios.put(presignedUrl, file, {
+            headers: { 'Content-Type': file.type },
+        });
+    } catch (error) {
+        console.error('Error uploading file:', error);
+        throw error;
+    }
+};
+
+
+export const createPost = async (postContent) => {
+    try {
+        const { data } = await axios.post(`${process.env.REACT_APP_POST_SERVICE_URL}/posts`, postContent);
+        return data;
+    } catch (error) {
+        console.error('Error creating post:', error);
+        throw error;
+    }
+};
 
 
 export const fetchPosts = async (token) => {
-        try {
-            const response = await axios.get(`${process.env.REACT_APP_API_GATEWAY_URL}/posts`,{
-                headers: {
-                    Authorization: `Bearer ${token}`,
-                },
-            });
-
-            console.log("API Response:", response.data);
-             return response.data || [];
-        } catch (error) {
-            console.error('Error fetching posts:', error);
-        }
-
+    try {
+        const { data } = await axios.get(`${process.env.REACT_APP_API_GATEWAY_URL}/posts`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+            },
+        });
+        return data || [];
+    } catch (error) {
+        console.error('Error fetching posts:', error);
+        throw error;
+    }
 };

--- a/frontend/onlypans-frontend/src/api/PostServiceApi.js
+++ b/frontend/onlypans-frontend/src/api/PostServiceApi.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 export const getPresignedUrl = async (fileName) => {
     try {
-        const { data } = await axios.get(`${process.env.REACT_APP_MEDIA_SERVICE_URL}/media/presigned-url`, {
+        const { data } = await axios.get(`${process.env.REACT_APP_API_GATEWAY_URL}/media/presigned-url`, {
             params: { fileName },
         });
         return data;
@@ -27,7 +27,7 @@ export const uploadFile = async (presignedUrl, file) => {
 
 export const createPost = async (postContent) => {
     try {
-        const { data } = await axios.post(`${process.env.REACT_APP_POST_SERVICE_URL}/posts`, postContent);
+        const { data } = await axios.post(`${process.env.REACT_APP_API_GATEWAY_URL}/posts`, postContent);
         return data;
     } catch (error) {
         console.error('Error creating post:', error);

--- a/frontend/onlypans-frontend/src/components/KeyCloakContext.js
+++ b/frontend/onlypans-frontend/src/components/KeyCloakContext.js
@@ -10,7 +10,7 @@ export const KeycloakProvider = ({ children }) => {
 
     useEffect(() => {
         const keycloakInstance = new Keycloak({
-            url: 'http://localhost:8081/',
+            url: process.env.REACT_APP_KEYCLOAK_URL,
             realm: 'onlypans',
             clientId: 'onlypans-frontend',
         });

--- a/frontend/onlypans-frontend/src/components/createpost.js
+++ b/frontend/onlypans-frontend/src/components/createpost.js
@@ -1,7 +1,6 @@
-import axios from 'axios';
-import * as React from 'react';
-import { useState } from 'react';
+import React, { useState } from 'react';
 import { Card, CardContent, CardMedia, Typography, Avatar, Box, TextField, Button, Modal, Backdrop, Snackbar, Alert } from '@mui/material';
+import { getPresignedUrl, uploadFile, createPost } from '../api/PostServiceApi';
 import placeholder from '../assets/placeholder.jpg';
 import user from '../assets/user.png';
 
@@ -27,28 +26,18 @@ function CreatePost({ open, onClose }) {
             return;
         }
 
-
-        console.log("Requesting presigned URL")
         try {
             const fileName = image.name;
-            const { data: presignedUrl } = await axios.get('http://localhost:8080/media/presigned-url', {
-                params: { fileName }
-            });
-
-            await axios.put(presignedUrl, image, {
-                headers: {
-                    'Content-Type': image.type
-                }
-            });
+            const presignedUrl = await getPresignedUrl(fileName);
+            await uploadFile(presignedUrl, image);
 
             const postContent = {
                 contentDescription: content,
                 authorName: 'someone',
-                mediaUrl: fileName
+                mediaUrl: fileName,
             };
 
-            const { data: createdPost } = await axios.post('http://localhost:8080/posts', postContent);
-            console.log("Created Post:", createdPost);
+            await createPost(postContent);
 
             setContent('');
             setImage(null);
@@ -61,7 +50,6 @@ function CreatePost({ open, onClose }) {
             alert('There was an error creating the post.');
         }
     };
-
 
     const handleCloseSuccess = () => {
         setSuccessOpen(false);
@@ -145,7 +133,6 @@ function CreatePost({ open, onClose }) {
                     </Card>
                 </Box>
             </Modal>
-
 
             <Snackbar
                 open={successOpen}

--- a/frontend/onlypans-frontend/src/components/createpost.js
+++ b/frontend/onlypans-frontend/src/components/createpost.js
@@ -4,7 +4,7 @@ import { getPresignedUrl, uploadFile, createPost } from '../api/PostServiceApi';
 import placeholder from '../assets/placeholder.jpg';
 import user from '../assets/user.png';
 
-function CreatePost({ open, onClose }) {
+function CreatePost({ open, onClose, token }) {
     const [content, setContent] = useState('');
     const [image, setImage] = useState(null);
     const [preview, setPreview] = useState(placeholder);
@@ -28,7 +28,7 @@ function CreatePost({ open, onClose }) {
 
         try {
             const fileName = image.name;
-            const presignedUrl = await getPresignedUrl(fileName);
+            const presignedUrl = await getPresignedUrl(fileName, token);
             await uploadFile(presignedUrl, image);
 
             const postContent = {
@@ -37,7 +37,7 @@ function CreatePost({ open, onClose }) {
                 mediaUrl: fileName,
             };
 
-            await createPost(postContent);
+            await createPost(postContent, token);
 
             setContent('');
             setImage(null);

--- a/frontend/onlypans-frontend/src/keycloak.js
+++ b/frontend/onlypans-frontend/src/keycloak.js
@@ -4,11 +4,13 @@ let keycloakInstance;
 
 export default function getKeycloak() {
     if (!keycloakInstance) {
+        console.log('Initializing Keycloak with URL:', process.env.KEYCLOAK_URL);
         keycloakInstance = new Keycloak({
-            url: 'http://localhost:8081/',
+            url: process.env.REACT_APP_KEYCLOAK_URL,
             realm: 'onlypans',
             clientId: 'onlypans-frontend',
         });
     }
     return keycloakInstance;
 }
+

--- a/frontend/onlypans-frontend/src/pages/AllPostsPage.jsx
+++ b/frontend/onlypans-frontend/src/pages/AllPostsPage.jsx
@@ -54,6 +54,7 @@ const AllPostsPage = ({keycloak, authenticated, user, showCreatePost, handleTogg
                     open={showCreatePost}
                     onClose={handleToggleCreatePost}
                     onPostCreate={handlePostCreate}
+                    token={token}
                 />
             </div>
             <div style={styles.scrollableContainer}>

--- a/live-docker-compose.yml
+++ b/live-docker-compose.yml
@@ -1,0 +1,149 @@
+version: '3.8'
+
+services:
+  # Keycloak service
+  keycloak:
+    image: quay.io/keycloak/keycloak:latest
+    container_name: keycloak
+    command: start-dev --import-realm --hostname-strict-https --hostname https://uni-onlypans-keycloak.kobos.studio --http-port 8081
+    env_file:
+      - ./configs/keycloak.env
+    volumes:
+      - ./configs/keycloak:/opt/keycloak/data/import
+    networks:
+      - captain-overlay-network
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'exec 3<>/dev/tcp/localhost/8081; echo -e "GET /health/ready HTTP/1.1\nhost: localhost:8080\n" >&3; timeout --preserve-status 1 cat <&3 | grep -m 1 status | grep -m 1 UP; ERROR=$?; exec 3<&-; exec 3>&-; exit $ERROR'
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  # Consul service
+  consul:
+    image: hashicorp/consul:latest
+    container_name: consul
+    restart: always
+    environment:
+      - CONSUL_BIND_INTERFACE=eth0
+    volumes:
+      - consul_data:/consul/data
+    command: agent -dev -ui -bind=0.0.0.0 -client=0.0.0.0 -advertise=10.0.1.89
+    depends_on:
+      - keycloak
+    networks:
+      - captain-overlay-network
+
+  subscription-service:
+    image: openjdk:21
+    container_name: subscription-service
+    volumes:
+      - ./backend_services/subscriptionService/build/libs/subscriptionService-1.0.0.jar:/app/service.jar
+    command: ["java", "-jar", "/app/service.jar"]
+    depends_on:
+      - consul
+      - api-gateway
+    env_file:
+      - ./configs/subscription_service.env
+    networks:
+      - captain-overlay-network
+
+  user-service:
+    image: openjdk:21
+    container_name: user-service
+    volumes:
+      - ./backend_services/userService/build/libs/userService-1.0.0.jar:/app/service.jar
+    command: ["java", "-jar", "/app/service.jar"]
+    depends_on:
+      - consul
+      - api-gateway
+    env_file:
+      - ./configs/user_service.env
+    networks:
+      - captain-overlay-network
+
+  api-gateway:
+    image: openjdk:21
+    container_name: api-gateway
+    volumes:
+      - ./api_gateway/build/libs/api_gateway-1.0.0.jar:/app/service.jar
+    command: ["java", "-jar", "/app/service.jar"]
+    depends_on:
+      keycloak:
+        condition: service_healthy
+      consul:
+        condition: service_started
+    env_file:
+      - ./configs/gateway.env
+    ports:
+      - 8080:8080
+    networks:
+      - captain-overlay-network
+
+  post-service:
+    image: openjdk:21
+    container_name: post-service
+    volumes:
+      - ./backend_services/postService/build/libs/postService-1.0.0.jar:/app/service.jar
+    command: ["java", "-jar", "/app/service.jar"]
+    depends_on:
+      - consul
+      - api-gateway
+    env_file:
+      - ./configs/post_service.env
+    networks:
+      - captain-overlay-network
+
+  media-service:
+    image: openjdk:21
+    container_name: media-service
+    volumes:
+      - ./backend_services/mediaService/build/libs/mediaService-1.0.0.jar:/app/service.jar
+    command: [ "java", "-jar", "/app/service.jar" ]
+    depends_on:
+      - consul
+      - api-gateway
+    env_file:
+      - ./configs/media_service.env
+    networks:
+      - captain-overlay-network
+
+  creator-service:
+    image: openjdk:21
+    container_name: creator-service
+    volumes:
+      - ./backend_services/creatorService/build/libs/creatorService-1.0.0.jar:/app/service.jar
+    command: [ "java", "-jar", "/app/service.jar" ]
+    depends_on:
+      - consul
+      - api-gateway
+    env_file:
+      - ./configs/creator_service.env
+    networks:
+      - captain-overlay-network
+
+  frontend:
+    build:
+      context: ./frontend/onlypans-frontend
+      dockerfile: Dockerfile
+    container_name: frontend
+    volumes:
+      - ./frontend/onlypans-frontend:/app
+      - /app/node_modules
+    env_file:
+      - ./configs/frontend.env
+    depends_on:
+      - api-gateway
+    networks:
+      - captain-overlay-network
+
+networks:
+  captain-overlay-network:
+    external: true
+
+volumes:
+  consul_data:


### PR DESCRIPTION
## Changes
- Added keycloak URLs for frontend live
- Added SSL certificates
- Added new redirect URLs for Google OAuth
- Recreated all environmental variables to use live URLs
- Edited JWT creation to match new keycloak deployment
- Upped MySQL max connections
- Add GitHub internal account to the docker-allowed group within the Ubuntu system
- Wrote nginx config to re-route /api to backend whilst stripping /api to not break Spring
- Wrote nginx config to re-route /consul to Consul whilst stripping /consul to not break API endpoints
- Similar nginx config for /v1 for Consul's API calls
- Deployed frontend live **[here](https://uni-onlypans-frontend.kobos.studio)**
- Deployed keycloak live **[here](https://uni-onlypans-keycloak.kobos.studio)**
- Deployed api live  **[here](https://uni-onlypans-frontend.kobos.studio/api)**
- Deployed consul live **[here](https://uni-onlypans-frontend.kobos.studio/consul)**
- Fixed networking over HTTP vs locally

## Deployed Microservices
-  ✅ Subscriptions Service
-  ✅ Post Service
-  ✅ User Service
-  ✅ Creator Profile Service
-  ✅ Media Service
-  ✅ KeyCloak
-  ✅ Consul


## CI/CD
- Add GitHub Runner to dedicated server 
  - Building JARs
  - Applying environmental variables securely
  - Deploying to Docker (in turn overwriting our NGINX reverse proxy with new backends)
- Add GitHub Actions file for processing 

## Static IPs
- Docker containers are all routed through the docker network & docker DNS
- My aim with these commits was to ensure we had a static IP, but due to the small available IP range left on the docker network being used, it was causing crashes.
- This did not impact reverse proxy though as it's possible to refresh the docker DNS internally

## Stripe Webhooks
- Stripe payment validation post-payment added.
  - We use metadata to activate a users subscription once payment confirmed.

## Nginx Snippet
```
 location /api/ {
            rewrite ^/api/(.*)$ /$1 break;
            proxy_pass http://api-gateway:8080;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;

            # Ensure API redirects correctly
            proxy_redirect / /api/;
        }

        # Consul passthrough
        location /consul/ {
            rewrite ^/consul(/.*)?$ $1 break;
            proxy_pass http://consul:8500;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;

            # Ensure Consul UI works correctly
            proxy_redirect / /consul/;
            sub_filter '/ui/' '/consul/ui/';
            sub_filter '"/v1/' '"/consul/v1/';
            sub_filter_once off;
        }

        # Wildcard match for Consul /v1 paths
        location /v1/ {
            rewrite ^/v1(/.*)?$ /v1$1 break;
            proxy_pass http://consul:8500;
            proxy_set_header Host $host;
            proxy_set_header X-Real-IP $remote_addr;
            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
            proxy_set_header X-Forwarded-Proto $scheme;

            # Ensure responses map back correctly
            proxy_redirect / /consul/;
        }
```